### PR TITLE
IS-99 Protect sign message

### DIFF
--- a/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
+++ b/ELN-0602 - Deployment Profile for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Deployment Profile for the Swedish eID Framework
 
-### Version 1.6 - 2019-10-22 - **Draft version**
+### Version 1.6 - 2019-11-01 - **Draft version**
 
 *ELN-0602-v1.6*
 
@@ -147,7 +147,7 @@ with caution.
 ### 1.2. References to SAML 2.0 Standards and Profiles
 
 When referring to elements from the SAML 2.0 core specification
-\[[SAML2Core](#saml2core)\], the following syntax is used:
+\[[7.2.](#saml2core)\], the following syntax is used:
 
 -   `<saml2p:Protocolelement>` – for elements from the SAML 2.0
     Protocol namespace.
@@ -1181,6 +1181,16 @@ by including the URIs of supported authentication contexts as EntityAttributes o
 *Example of how an Identity Provider advertises its support for LoA 3
 authentication (including support for displaying of sign messages).*
 
+If an Identity Provider that has ways of determining the principal's identity before displaying
+a sign message receives a `<psc:PrincipalSelection>` extension in  the authentication request 
+it SHOULD ensure that the contents of the `<psc:PrincipalSelection>` extension matches the 
+principal identity. If there is a mismatch, the Identity Provider MUST NOT display the
+sign message, and if the request states that the sign message must be displayed, fail with
+an error response where the second-level status code is set to
+`urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal` \[[SAML2Core](#saml2core)\].
+
+> Typical scenarios where the above requirement apply is for the Swedish eIDAS connector that first authenticates a principal and then displays the sign message, and for Identity Providers that prompt the user for its user identity as part of its authentication scheme. In those scenarios the Identity Providers must compare the principal identity with the contents of `<psc:PrincipalSelection>`, if received in the authentication request. 
+
 Identity Providers processing a request with a requested authentication
 context that is a "Sign Message Authentication Context URI" SHALL meet the
 following requirements (in addition to other general requirements
@@ -1491,6 +1501,7 @@ A service wishing to receive encrypted messages where SHA-1 is not used as the k
 - This profile is no longer normatively dependent upon SAML2Int. Therefore, the profile has been updated with requirements that previously was implicit (due to the normative dependency to SAML2Int).
 - Section 8, "Cryptographic Algorithms", was introduced in order to clearly define the algorithm requirements for services that are conformant to this profile.
 - Section 2.1.1 was updated with elaborations concerning certificates in metadata.
+- Section 7.2.1 was updated with a requirement that ensures that a sign message is only displayed to the intended user.
 
 **Changes between version 1.4 and 1.5:**
 

--- a/ELN-0612 - BankID Profile for the Swedish eID Framework.md
+++ b/ELN-0612 - BankID Profile for the Swedish eID Framework.md
@@ -2,7 +2,7 @@
 
 # Implementation Profile for BankID Identity Providers within the Swedish eID Framework
 
-### Version 1.2 - 2019-10-31 - **Draft version**
+### Version 1.2 - 2019-11-01 - **Draft version**
 
 *ELN-0612-v1.2*
 
@@ -350,6 +350,9 @@ An Identity Provider conforming to the Swedish eID Framework is obliged to handl
 
 The BankID client (app or desktop program) comprises a text box in which the signature message is displayed for the user. A BankID Identity Provider MUST NOT display the signature message in any other way than in this text box. How the signature message is assigned is specified below.
 
+If the BankID Identity Provider prompts the user for his or hers personal identity number in order to initialize
+the BankID signature operation, the Identity Provider MUST honour the requirement that ensures that a sign message is only displayed to the intended principal, see section 7.2.1 in \[[EidProfile](#eid-profile)\].
+
 <a name="input-to-bankid-signing"></a>
 #### 4.2.1. Input to BankID Signing
 
@@ -572,6 +575,8 @@ using the `secure-authenticator-binding` entity category, may request that QR co
 - Section 6.2 was updated with a requirement that a BankID Identity Provider should include the `<psc:RequestedPrincipalSelection>` element in its metadata.
 
 - The recommendation in section 3.2 concerning handling of non default browsers was updated.
+
+- Section 4.2 was updated with a requirement that ensures that only the intended user sees a sign message.
 
 **Changes between version 1.0 and 1.1:**
 

--- a/ELN-0614 - Principal Selection in SAML Authentication Requests.md
+++ b/ELN-0614 - Principal Selection in SAML Authentication Requests.md
@@ -2,7 +2,7 @@
 
 # Principal Selection in SAML Authentication Requests 
 
-### Version 1.0 - 2019-08-30 - *Draft version*
+### Version 1.0 - 2019-11-01 - *Draft version*
 
 *ELN-0614-v1.0*
 
@@ -47,7 +47,13 @@ This specification defines the `<psc:PrincipalSelection>` element that may be in
 
 The specification also defines the `<psc:RequestedPrincipalSelection>` element that should be used by Identity Providers that may need information about a known user in order to avoid prompting for the user ID<sup>1</sup>. The element should be included as an extension in the Identity Provider metadata under the `<md:IDPSSODescriptor>` element.
 
-> \[1]\: The typical use case is when a user once has authenticated for a service and provided his or hers user ID to the Identity Provider, and is about to perform a signature. If the Identity Provider prompts the user for the user ID once again the user experience is poor and the Service Provider will receive customer complaints.
+Even though the main purpose of the `<psc:PrincipalSelection>` extension is to aid the Identity Provider
+in selecting a particular subject for the authentication, an Identity Provider MAY also compare the match 
+values present in the extension with the resulting attributes from the user authentication, and in case of a 
+mismatch, respond with an error. In these cases the second-level SAML status code MUST be set to
+`urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal` \[[SAML2Core](#saml2core)\].
+
+> \[1\]: The typical use case is when a user once has authenticated for a service and provided his or hers user ID to the Identity Provider, and is about to perform a signature. If the Identity Provider prompts the user for the user ID once again the user experience is poor and the Service Provider will receive customer complaints.
 
 <a name="requirements-notation"></a>
 ### 1.1. Requirements Notation
@@ -223,6 +229,12 @@ The following XML schema defines the `http://id.swedenconnect.se/authn/1.0/princ
 
 > [Bradner, S., Key words for use in RFCs to Indicate Requirement
 > Levels, March 1997](http://www.ietf.org/rfc/rfc2119.txt).
+
+<a name="saml2core"></a>
+**\[SAML2Core\]**
+> [OASIS Standard, Assertions and Protocols for the OASIS Security
+> Assertion Markup Language (SAML) V2.0, March
+> 2005.](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)
 
 <a name="eidattributes"></a>
 **[EidAttributes]**


### PR DESCRIPTION
Added requirements that ensure that a sign message is not display to an unintended principal.