### PR TITLE
IS-129 Version handling

### DIFF
--- a/07 - Implementation Profile for using DSS in Central Signing Services.md
+++ b/07 - Implementation Profile for using DSS in Central Signing Services.md
@@ -8,7 +8,7 @@
 
 #  Implementation Profile for using OASIS DSS in Central Signing Services
 
-### Version 1.4 - 2020-01-17
+### Version 1.5 - 2020-09-21 - *Draft version*
 
 Registration number: **2019-312** (*previously: ELN-0607*)
 
@@ -78,7 +78,7 @@ Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Go
 
     2.2.4. [DSS Extension](#dss-extension)
 
-    2.2.4.1. [Version](#version)
+    2.2.4.1. [Version](#version2)
 
     2.2.4.2. [ResponseTime](#responsetime)
 
@@ -219,9 +219,13 @@ conditions of the following subsections.
 <a name="version"></a>
 ##### 2.1.3.1. Version
 
-The version of the \[[DSS-Ext](#dss-ext)\] specification MUST be "1.1" (default).
-The version attribute MUST either be absent (default value) or MUST
-specify the value “1.1”.
+The `Version` attribute giving the version number of the \[[DSS-Ext](#dss-ext)\] specification
+SHOULD be set to the version number that is supported by the sender.
+If absent, the default value "1.1" MUST be assumed.
+
+If a version, not supported by the Signature Service, is requested, the Signature Service MUST 
+refuse to process the request and respond with an error message where `<dss:ResultMajor>` is set to `urn:oasis:names:tc:dss:1.0:resultmajor:RequesterError` and the `<dss:ResultMinor>` is set
+to `urn:oasis:names:tc:dss:1.0:resultminor:NotSupported`.
 
 <a name="conditions"></a>
 ##### 2.1.3.2. Conditions
@@ -341,12 +345,12 @@ in the `AuthnRequest` sent to the Identity Provider when authenticating
 the user for signing:
 
 1. Determine requested LoA (Level of Assurance) by either:
-  1. Get the LoA from the `AuthnContextClassRef` specified in the sign request as `CertRequestProperties`, or
+  1. Get the LoA, or LoA:s, from the `AuthnContextClassRef` specified in the sign request as `CertRequestProperties`, or
   2. if the LoA reference from the sign request is absent then use the default LoA according to the governing policy.
   
-2. Include the LoA URI from the step above as `RequestedAuthnContext` if supported by the Identity Provider.
-   If this LoA is not supported by the Identity Provider, fail signing and return an error sign response,
-   indicating a request failure (the requested LoA was inconsistent with the specified Identity Provider).
+2. Include the LoA URI(s) from the step above as `RequestedAuthnContext` if supported by the Identity Provider.
+   If none of the LoA:s are supported by the Identity Provider, fail signing and return an error sign response,
+   indicating a request failure (the requested LoA(s) was inconsistent with the specified Identity Provider).
 
 
 **Deprecated process:**
@@ -433,9 +437,8 @@ When the `CertType` attribute is present with a value of `QC/SSCD` the signature
 <a name="authncontextclassref"></a>
 ###### 2.1.3.9.1. AuthnContextClassRef
 
-This element MAY be present to specify the Level of Assurance required
-in order to issue the signing certificate. This element serves only to
-determine the Level of Assurance required.
+This element MAY be present to specify the Level of Assurance(s) required
+in order to issue the signing certificate. 
 
 <a name="requestedcertattributes"></a>
 ###### 2.1.3.9.2. RequestedCertAttributes
@@ -525,12 +528,15 @@ The `<dss:OptionalInput>` element of the sign response MUST contain
 a `<SignResponseExtension>` element according to requirements and
 conditions of the following subsections.
 
-<a name="version"></a>
+<a name="version2"></a>
 ##### 2.2.4.1. Version
 
-The version of the DSS-Ext specification MUST be "1.1" (default).
-The version attribute MUST either be absent (default value) or MUST
-specify the value “1.1”.
+The version of the \[[DSS-Ext](#dss-ext)\] specification under which the 
+request was processed and response was constructed. This version MUST be the same
+version as given in the `SignRequestExtension` (see section [2.1.3.1](#version), "[Version](#version))".
+
+For backwards compatibility reasons that attribute MAY be absent if version "1.1" was requested. 
+Otherwise it MUST be set.
 
 <a name="responsetime"></a>
 ##### 2.2.4.2. ResponseTime
@@ -727,7 +733,7 @@ EidSignResponse | Base64 encoded sign response.
 
 <a name="dss-ext"></a>
 **[DSS-Ext]**
-> [DSS Extension for Federated Central Signing Services](https://docs.swedenconnect.se/technical-framework/latest/09_-_DSS_Extension_for_Federated_Signing_Services.html).
+> [DSS Extension for Federated Central Signing Services](https://docs.swedenconnect.se/technical-framework/updates/09_-_DSS_Extension_for_Federated_Signing_Services.html).
 
 <a name="eid-registry"></a>
 **[Eid-Registry]**
@@ -742,6 +748,10 @@ EidSignResponse | Base64 encoded sign response.
 
 <a name="changes-between-versions"></a>
 ## 5. Changes between versions
+
+**Changes between version 1.4 and version 1.5:**
+
+- Sections 2.1.3.1 and 2.2.4.1 defining the requirements concerning the use of the `Version` attribute in `SignRequestExtension` and `SignResponseExtension` elements were updated in order to implement support for newer versions of the DSS extension specification.
 
 **Changes between version 1.3 and version 1.4:**
 

--- a/07 - Implementation Profile for using DSS in Central Signing Services.md
+++ b/07 - Implementation Profile for using DSS in Central Signing Services.md
@@ -223,10 +223,6 @@ The `Version` attribute giving the version number of the \[[DSS-Ext](#dss-ext)\]
 SHOULD be set to the version number that is supported by the sender.
 If absent, the default value "1.1" MUST be assumed.
 
-If a version, not supported by the Signature Service, is requested, the Signature Service MUST 
-refuse to process the request and respond with an error message where `<dss:ResultMajor>` is set to `urn:oasis:names:tc:dss:1.0:resultmajor:RequesterError` and the `<dss:ResultMinor>` is set
-to `urn:oasis:names:tc:dss:1.0:resultminor:NotSupported`.
-
 <a name="conditions"></a>
 ##### 2.1.3.2. Conditions
 

--- a/09 - DSS Extension for Federated Signing Services.md
+++ b/09 - DSS Extension for Federated Signing Services.md
@@ -343,8 +343,14 @@ attributes and elements:
 
 > This attribute provides means for the receiving
 > service to determine the expected semantics of the request based on the
-> protocol version. The receiving service MUST use the same version
+> protocol version. 
+
+> The receiving service MUST use the same version
 > in the resulting response, see [section 3.2](#element-signresponseextension).
+> If the receiving service does not support the requested version, the service 
+> MUST refuse to process the request and respond with an error message where 
+> `<dss:ResultMajor>` is set to `urn:oasis:names:tc:dss:1.0:resultmajor:RequesterError`
+> and the `<dss:ResultMinor>` is set to `urn:oasis:names:tc:dss:1.0:resultminor:NotSupported`.
 
 `<RequestTime>` \[Required\]
 

--- a/09 - DSS Extension for Federated Signing Services.md
+++ b/09 - DSS Extension for Federated Signing Services.md
@@ -8,7 +8,7 @@
 
 # DSS Extension for Federated Central Signing Services
 
-### Version 1.4 - 2020-06-22 - *Draft version*
+### Version 1.4 - 2020-09-21 - *Draft version*
 
 Registration number: **2019-314** (*previously: ELN-0609*)
 
@@ -179,7 +179,10 @@ This schema is associated with the following XML namespace:
 
 `http://id.elegnamnden.se/csig/1.1/dss-ext/ns`
 
-If a future version of this specification is needed, it will use a
+Compliance with this specification requires support of the latest version of 
+the \[[Csig-XSD](#csig-xsd)\] schema which is 1.1.2.
+
+If a future, non backwards compatible, version of this specification is needed, it will use a
 different namespace.
 
 Conventional XML namespace prefixes are used in the schema:
@@ -333,12 +336,15 @@ element in a DSS Sign Request. This element's
 **SignRequestExtensionType** complex type includes the following
 attributes and elements:
 
-`Version` \[Optional\] (Default `1.2`)
+`Version` \[Optional\] (Default `1.1`)
 
-> The version of this specification. If absent, the version value
-> defaults to "1.2". This attribute provides means for the receiving
+> The version of this specification supported by the sender. If absent, 
+> the version value defaults to "1.1". 
+
+> This attribute provides means for the receiving
 > service to determine the expected semantics of the request based on the
-> protocol version.
+> protocol version. The receiving service MUST use the same version
+> in the resulting response, see [section 3.2](#element-signresponseextension).
 
 `<RequestTime>` \[Required\]
 
@@ -424,7 +430,7 @@ element and its **SignRequestExtensionType** complex type:
     <xs:element minOccurs="0" ref="csig:SignMessage" maxOccurs="unbounded" />
     <xs:element minOccurs="0" ref="csig:OtherRequestInfo" />
   </xs:sequence>
-  <xs:attribute name="Version" type="xs:string" use="optional" default="1.2" />
+  <xs:attribute name="Version" type="xs:string" use="optional" default="1.1" />
 </xs:complexType>
 ```
 
@@ -466,6 +472,8 @@ attributes and elements:
 > `saml:RequestedAuthnContext` element is included in the `saml:AuthnRequest`.
 > In the latter case the Signature Service puts no requirements on the
 > required level of assurance.
+
+> **Note:** If more than one URI is given, the `Version` attribute of the `SignRequestExtension` element MUST be set to "1.4" or higher. Implementations prior to version 1.4 of this specification assume that this element may only contain one URI.
 
 
 `<RequestedCertAttributes>` \[Optional\]
@@ -758,12 +766,16 @@ element.
 This element's **SignResponseExtensionType** complex type includes the
 following attributes and elements:
 
-`Version` \[Optional\] (Default `1.2`)
+`Version` \[Optional\] (Default `1.1`)
 
-> The version of this specification. If absent, the version value
-> defaults to "1.2". This attribute provides means for the receiving
+> The version of this specification under which the response message was produced. 
+> If absent, the version value
+> defaults to "1.1". This attribute provides means for the receiving
 > service to determine the expected semantics of the response based on the
 > protocol version.
+
+> **Note:** The sender MUST use the same version number as received in the `Version`
+> attribute of the `SignRequestExtension` (see [section 3.1](#element-signrequestextension)).
 
 `<ResponseTime>` \[Required\]
 
@@ -1225,7 +1237,7 @@ signature and MUST check that the signature covers all data in the
 **\[Csig-XSD\]**
 > This specification's DSS Extensions schema Version 1.1, https://docs.swedenconnect.se/schemas/csig/1.1/EidCentralSigDssExt-1.1.xsd, August 2015.
 
-> See also the draft version: https://docs.swedenconnect.se/schemas/csig/1.2/EidCentralSigDssExt-1.2-DRAFT.xsd, June 2020.
+> See also the draft version: https://docs.swedenconnect.se/schemas/csig/1.1/EidCentralSigDssExt-1.1.2-DRAFT.xsd, June 2020.
 
 <a name="dss"></a>
 **\[OASIS-DSS\]**
@@ -1281,7 +1293,9 @@ Recommendation 26 November 2008](https://www.w3.org/TR/REC-xml/).
 
 **Changes between version 1.3 and 1.4:**
 
-- Section 3.1.1, "Type CertRequestPropertiesType", was updated so that more than one `<saml:AuthnContextClassRef>` element can be included. The schema was also updated accordingly. 
+- Section 3.1 and 3.2 was updated to clarify the use of the `Version` attribute in the `SignRequestExtension` and `SignResponseExtension` elements.
+
+- Section 3.1.1, "Type CertRequestPropertiesType", was updated so that more than one `<saml:AuthnContextClassRef>` element can be included. The schema was also updated (to version 1.1.2 but keeping the same namespace identifier). 
 
 **Changes between version 1.2 and 1.3:**
 
@@ -1305,21 +1319,23 @@ sections above, the XML Schema in this appendix is the normative one.
 
 The schema can also be downloaded from https://docs.swedenconnect.se/schemas/csig/1.1/EidCentralSigDssExt-1.1.xsd.
 
-> See also: https://docs.swedenconnect.se/schemas/csig/1.2/EidCentralSigDssExt-1.2-DRAFT.xsd.
+> See also: https://docs.swedenconnect.se/schemas/csig/1.1/EidCentralSigDssExt-1.1.2-DRAFT.xsd.
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    version="1.1.2"
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-    targetNamespace="http://id.elegnamnden.se/csig/1.2/dss-ext/ns"
+    targetNamespace="http://id.elegnamnden.se/csig/1.1/dss-ext/ns"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:dss="urn:oasis:names:tc:dss:1.0:core:schema"
-    xmlns:csig="http://id.elegnamnden.se/csig/1.2/dss-ext/ns">
+    xmlns:csig="http://id.elegnamnden.se/csig/1.1/dss-ext/ns">
 
   <xs:annotation>
     <xs:documentation>
-      Schema location URL: https://docs.swedenconnect.se/schemas/csig/1.2/EidCentralSigDssExt-1.2-DRAFT.xsd
+      Version: 1.1.2
+      Schema location URL: https://docs.swedenconnect.se/schemas/csig/1.1/EidCentralSigDssExt-1.1.2-DRAFT.xsd
     </xs:documentation>
   </xs:annotation>
 
@@ -1557,12 +1573,10 @@ The schema can also be downloaded from https://docs.swedenconnect.se/schemas/csi
       <xs:element ref="csig:SignMessage" minOccurs="0" maxOccurs="1" />
       <xs:element ref="csig:OtherRequestInfo" minOccurs="0" />
     </xs:sequence>
-    <xs:attribute name="Version" type="xs:string" use="optional" default="1.2">
+    <xs:attribute name="Version" type="xs:string" use="optional" default="1.1">
       <xs:annotation>
         <xs:documentation>
-          The version of this specification. If absent, the version value defaults to "1.2". 
-          This attribute provide means for the receiving service to determine the 
-          expected semantics of the response based on protocol version.
+          The version of the DSS specification. If absent, the version value defaults to "1.1".
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
@@ -1576,12 +1590,10 @@ The schema can also be downloaded from https://docs.swedenconnect.se/schemas/csi
       <xs:element ref="csig:SignatureCertificateChain" minOccurs="0" />
       <xs:element ref="csig:OtherResponseInfo" minOccurs="0" />
     </xs:sequence>
-    <xs:attribute name="Version" type="xs:string" default="1.2">
+    <xs:attribute name="Version" type="xs:string" default="1.1">
       <xs:annotation>
         <xs:documentation>
-          The version of this specification. If absent, the version value defaults to "1.2". 
-          This attribute provide means for the receiving service to determine the 
-          expected semantics of the response based on protocol version.
+          The version of the DSS specification. If absent, the version value defaults to "1.1".
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
Reverted to 1.1 CSIG namespace for 1.1.2 draft.
Added clarifications on how to use Version attributes.