### PR TITLE
Feature/is 161 remove svt drafts

### DIFF
--- a/03 - Registry for Identifiers.md
+++ b/03 - Registry for Identifiers.md
@@ -8,7 +8,7 @@
 
 # Swedish eID Framework - Registry for identifiers
 
-### Version 1.7 - 2021-09-21 - *Draft version*
+### Version 1.7 - 2021-09-23 - *Draft version*
 
 Registration number: **2019-309** (*previously: ELN-0603*)
 
@@ -556,7 +556,7 @@ Object Identifier Registry for Sweden Connect<sup>*</sup>
 
 <a name="svt-pdf"></a>
 **\[SVT-PDF\]**
-> [PDF Profile for Signature Validation Tokens](http://docs.swedenconnect.se/technical-framework/updates/16_-_PDF_Profile_for_Signature_Validation_Tokens.html).
+> [PDF Signature Validation Token](https://datatracker.ietf.org/doc/draft-santesson-svt-pdf/).
 
 <a name="eidas"></a>
 **\[eIDAS\]**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This specification defines an element that may be included in the Extensions ele
 
 > [14 - Principal Selection in SAML Authentication Requests](14%20-%20Principal%20Selection%20in%20SAML%20Authentication%20Requests.md)
 
-#### Signature Validation Tokens
+#### *Signature Validation Tokens*
 
 The draft specifications "15 - Signature Validation Token", "16 - PDF Profile for Signature Validation Tokens" and "17 - XML Profile for Signature Validation Tokens" are no longer part of the Swedish eID Framework specifications, and have been replaced by the following IETF drafts:
 
@@ -130,7 +130,7 @@ See https://github.com/swedenconnect/IETF-SVT for the repository that is hosting
 
 ## Older versions
 
-Older version of the specification are stored in the following branches:
+Older version of the specifications are stored in the following branches:
 
 + [june-2014](https://github.com/swedenconnect/technical-framework/tree/june-2014) - For the June 2014 release
 + [april-2015](https://github.com/swedenconnect/technical-framework/tree/april-2015) - For the April 2015 release

--- a/README.md
+++ b/README.md
@@ -116,24 +116,15 @@ This specification defines an element that may be included in the Extensions ele
 
 > [14 - Principal Selection in SAML Authentication Requests](14%20-%20Principal%20Selection%20in%20SAML%20Authentication%20Requests.md)
 
-#### Signature Validation Token
+#### Signature Validation Tokens
 
-The "Signature Validation Token" specification defines a basic token to support signature validation in a way that can significantly extend the lifetime of a signature.
+The draft specifications "15 - Signature Validation Token", "16 - PDF Profile for Signature Validation Tokens" and "17 - XML Profile for Signature Validation Tokens" are no longer part of the Swedish eID Framework specifications, and have been replaced by the following IETF drafts:
 
-> [15 - Signature Validation Token](15%20-%20Signature%20Validation%20Token.md) - *Draft*
+- [https://datatracker.ietf.org/doc/draft-santesson-svt/](https://datatracker.ietf.org/doc/draft-santesson-svt/)
+- [https://datatracker.ietf.org/doc/draft-santesson-svt-pdf/](https://datatracker.ietf.org/doc/draft-santesson-svt-pdf/)
+- [https://datatracker.ietf.org/doc/draft-santesson-svt-xml/](https://datatracker.ietf.org/doc/draft-santesson-svt-xml/)
 
-#### PDF Profile for Signature Validation Tokens
-
-Defines a profile for implementing SVT with a signed PDF document, covering how to include reference data related to PDF signatures and PDF documents in an SVT and how to add an SVT token to a PDF document.
-
-> [16 - PDF Profile for Signature Validation Tokens](16%20-%20PDF%20Profile%20for%20Signature%20Validation%20Tokens.md) - *Draft*
-
-#### XML Profile for Signature Validation Tokens
-
-Defines a profile for implementing SVT with a signed XML document, covering how to include reference data related to XML signatures and XML documents in an SVT and how to add an SVT token to a XML signature.
-
-> [17 - XML Profile for Signature Validation Tokens](17%20-%20XML%20Profile%20for%20Signature%20Validation%20Tokens.md) - *Draft*
-
+See https://github.com/swedenconnect/IETF-SVT for the repository that is hosting this work.
 
 ---
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,10 +38,7 @@ declare -a SPECIFICATIONS=("00 - Tekniskt ramverk - Introduktion"
     "11 - eIDAS Constructed Attributes Specification for the Swedish eID Framework"
     "12 - BankID Profile for the Swedish eID Framework"
     "13 - Signature Activation Protocol"
-    "14 - Principal Selection in SAML Authentication Requests"
-    "15 - Signature Validation Token"
-    "16 - PDF Profile for Signature Validation Tokens"
-    "17 - XML Profile for Signature Validation Tokens")
+    "14 - Principal Selection in SAML Authentication Requests")
 
 #
 # Produce HTML

--- a/versions.md
+++ b/versions.md
@@ -16,9 +16,9 @@
 | [12 - BankID Profile for the Swedish eID Framework](12%20-%20BankID%20Profile%20for%20the%20Swedish%20eID%20Framework.md) | 1.3<br />(draft) |
 | [13 - Signature Activation Protocol for Federated Signing](13%20-%20Signature%20Activation%20Protocol.md) | 1.1 |
 | [14 - Principal Selection in SAML Authentication Requests](14%20-%20Principal%20Selection%20in%20SAML%20Authentication%20Requests.md) | 1.0 |
-| [15 - Signature Validation Token](15%20-%20Signature%20Validation%20Token.md) | 1.0<br/>(draft) |
-| [16 - PDF Profile for Signature Validation Tokens](16%20-%20PDF%20Profile%20for%20Signature%20Validation%20Tokens.md) | 1.0<br/>(draft) |
-| [17 - XML Profile for Signature Validation Tokens](17%20-%20XML%20Profile%20for%20Signature%20Validation%20Tokens.md) | 1.0<br/>(draft) |
+| ~~15 - Signature Validation Token~~<br /><br />Replaced by IETF draft: https://datatracker.ietf.org/doc/draft-santesson-svt/ | ~~1.0<br/>(draft)~~ |
+| ~~16 - PDF Profile for Signature Validation Tokens~~<br /><br />Replaced by IETF draft: https://datatracker.ietf.org/doc/draft-santesson-svt-pdf/ | ~~1.0<br/>(draft)~~ |
+| ~~17 - XML Profile for Signature Validation Tokens~~ <br /><br />Replaced by IETF draft: https://datatracker.ietf.org/doc/draft-santesson-svt-xml/ | ~~1.0<br/>(draft)~~ |
 
 
 

--- a/versions.md
+++ b/versions.md
@@ -1,5 +1,5 @@
 
-## Version numbers on specifications ##
+## Version Numbers on Swedish eID Framework Specifications ##
 
 | File | Version |
 | :--- | :---: |   


### PR DESCRIPTION
Removed SVT drafts. They are now IETF drafts.

Closes #161 