### PR TITLE
Feature/is 207 update identity matching

### DIFF
--- a/Identity Binding.md
+++ b/Identity Binding.md
@@ -1,3 +1,4 @@
+
 <p>
 <img align="left" src="img/sweden-connect.png"></img>
 <img align="right" src="img/digg_centered.png"></img>
@@ -8,15 +9,15 @@
 
 # Binding of eIDAS Identities to Records in the Swedish Population Register
 
-### 2023-06-09
+### 2024-05-08
 
-This document contains information about the binding processes that 
-associate a Swedish identity number to an eIDAS notified eID.
+This document contains information about the processes that bind a Swedish identification number to an eIDAS notified eID.
 
 ---
 
 <p class="copyright-statement">
-Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Government (DIGG)</a>, 2023. All Rights Reserved.
+Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Government (DIGG)</a>, 
+2023-2024. All Rights Reserved.
 </p>
 
 ## Table of Contents
@@ -28,219 +29,124 @@ Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Go
     2.1. [Making a Binding](#making-a-binding)
     
     2.2. [eIDAS-node Queries](#eidas-node-queries)
-
-3. [**Identity Binding Levels**](#identity-binding-levels)
-
-    3.1. [Basic Binding](#basic-binding)
     
-    3.2. [Enhanced Binding](#enhanced-binding)
-    
-    3.3. [Verified Binding](#verified-binding)
-    
-4. [**Identity Binding Processes**](#identity-binding-processes)
+3. [**Identity Binding Processes**](#identity-binding-processes)
 
-    4.1. [Essential Matching of Record in the Population Register](#essential-matching-population-register)
+    3.1. [End-user Holds an Account in the Identity Binding Service](#identity-binding-user)
 
-    4.2. [Elevated Matching of Record in the Poulation Register](#elevated-matching-population-register)
+    3.2. [End-user Holds a Copy of Record From the Swedish Population Register](#population-register)
     
-    4.3. [Nordic Identification Number Found in the Population Register](#nordic-id-in-population-register)
+    3.3. [Nordic Identification Number Correspond to Record in the Swedish Population Register](#nordic-id)
 
-    4.4. [Use of Swedish eID](#use-of-swedish-eid)
+    3.4. [End-user Electronically Signed the Copy of Record by Using his/her Swedish eID](#user-with-swedish-eid)
     
-    4.5. [A Relative to End-user has Confirmed the Binding](#confirmed-by-relative)
+    3.5. [A Relative to End-user Confirmed the Binding](#confirmed-by-relative)
  
-    4.6. [Passport or ID-card Scanning](#passport-or-id-card-scanning)
-    
-5. [**Versions**](#versions)
+4. [**Versions**](#versions)
     
 <a name="introduction"></a>
 ## 1. Introduction
 
-Public relying parties in Sweden commonly use the Swedish personal 
-identity number (a.k.a. personnummer) or the Swedish coordination 
-number (a.k.a. samordningsnummer) as the primary identifier to carry 
-out the authorization of an authenticated user. These attributes are 
-not part of an eIDAS assertion received from an another country even
-if the authenticated user holds a Swedish identity number.  
+In Sweden, public relying parties commonly utilize the Swedish personal identity number (a.k.a. personnummer) or the Swedish coordination number (a.k.a. samordningsnummer) as the primary identifier for authorizing authenticated users. However, these identifiers are not part of an eIDAS assertion and can't be received from another country, even if the user holds such as Swedish identity number.
 
-Using an Identity Binding Service, end users can associate 
-their eIDAS eID with their record in the Swedish population 
-register. And, in such manner, end users can gain access to more 
-Swedish digital services.
+By utilizing the Sweden Connect Identity Binding Service, end-users can associate their eIDAS eID with their record in the Swedish population register. This process enables end-users to access a broader range of Swedish digital services. 
+
 
 <a name="the-identity-binding-service"></a>
 ## 2. The Identity Binding Service
 
-The Identity Binding Service is a part of the Swedish eIDAS infrastructure.
-For users that hold an eIDAS notified eID, it provides support in binding processes,
-which give end users the ability to associate their eID to a record in the Swedish
-population register. 
+The Identity Binding Service is a part of the Swedish eIDAS infrastructure. It supports users with eIDAS-notified eIDs by facilitating binding processes, allowing them to link their eID to a record in the Swedish population register.
 
-When records have been matched, this identity binding can be utilized 
-by the Swedish eIDAS-node when the end user attempts to log in to a Swedish digital 
-service using his or hers foreign eID. The assertion that is provided to relying party 
-includes attributes from eIDAS as well as attributes from the Identity Binding Service.
+Once records are successfully associated to the user's eID, this identity binding can be leveraged by the Swedish eIDAS node when an end-user attempts to log in to a Swedish digital service using their foreign eID. The resulting assertion provided to the relying party includes attributes from eIDAS, as well as attributes 
+from the Identity Binding Service.
 
+The Identity Binding Service can be used by end-users, who are authenticated through eIDAS under specific conditions:
 
-The Identity Binding Service can be used by end users, who are authenticated through 
-eIDAS, in the cases when:
+- The end-user must have a registered record in terms of Swedish personal identity number (a.k.a. personnummer) or Swedish coordination number (a.k.a. samordningsnummer) in the Swedish population register.
+- The end-user must opt to associate this record to his or her eIDAS notified eID.
 
-- the end user has a registered record in terms of Swedish personal identity number 
-(a.k.a. personnummer) or Swedish coordination number (a.k.a. samordningsnummer) in the
-Swedish population register, and
-- the end user has chosen to associate this record to his or her eIDAS notified eID.
+Once an end-user's Swedish record is linked to hir or her foreing eID, the Swedish eIDAS node can include this information in the assertion provided to the relying party.
 
-When ab end user's Swedish record are linked to his or her eID, the Swedish eIDAS-node can 
-provide this information in the assertion to relying party.
 
 <a name="making-a-binding"></a>
 ### 2.1. Making a Binding
 
-Identity binding can be made through a number of different 
-[Identity Binding Processes](#identity-binding-processes). These processes are run separately
-or in combination and can result in an identity binding based on three different levels
-of confidence. See also [section 3, "Identity Binding Levels"](#identity-binding-levels)
+A user can make an identity binding through a various [Identity Binding Processes](#identity-binding-processes). These processes are run independently or in combination, aimed at achieving a clear and unambiguous identity binding.
     
 <a name="eidas-node-queries"></a>
 ### 2.2. eIDAS-node Queries
 
-The identity bindings of the Identity Binding service will be accessible for the
-Swedish eIDAS-node via a query-API. During an eIDAS authentication, the Swedish eIDAS-node
-will query this API for a binding between the attributes presented in the assertion 
-received from the foreign node and a Swedish personal identity number. If such a
-binding exists two attributes will be added to the resulting assertion delivered to
-the Swedish relying party (service provider). These attributes are:
+The identity bindings that are created and stored by the end-user in a private area of the Identity Binding service can be accessible from the Swedish eIDAS node through a query API. 
+
+During a process of eIDAS authentication, the Swedish eIDAS node will use this API to check for a binding between the attributes presented in the assertion received from the eIDAS node outside Sweden. If such a binding exists, two attributes will be included in the resulting assertion provided to the Swedish relying 
+party (service provider). These attributes are:
 
 - `urn:oid:1.2.752.201.3.16` (mappedPersonalIdentityNumber) - Contains the Swedish
-personal identity number that was bound to the eIDAS identity.
+personal identity number that is associated to the eIDAS identity.
 
-- `urn:oid:1.2.752.201.3.6` (personalIdentityNumberBinding) - Contains an URI that
-represents the [Identity Binding Level](#identity-binding-levels).
+- `urn:oid:1.2.752.201.3.6` (personalIdentityNumberBinding) - Contains URI:s that represents the [Identity Binding Processes](#identity-binding-processes).
 
-See also sections 2.5, "eIDAS Natural Person Attribute Set", and 3.3.2, "The mappedPersonalIdentityNumber and personalIdentityNumberBinding Attributes", of [Attribute Specification for the Swedish eID Framework](https://docs.swedenconnect.se/technical-framework/updates/04_-_Attribute_Specification_for_the_Swedish_eID_Framework.html) for more information
-about attribute release during an eIDAS authentication.
+See also sections 2.5, "eIDAS Natural Person Attribute Set", and 3.3.2, "The mappedPersonalIdentityNumber and personalIdentityNumberBinding Attributes", of [Attribute Specification for the Swedish eID Framework](https://docs.swedenconnect.se/technical-framework/updates/04_-_Attribute_Specification_for_the_Swedish_eID_Framework.html) for more information about attribute release during an eIDAS authentication.
 
-<a name="identity-binding-levels"></a>
-## 3. Identity Binding Levels
-
-Identity Bindings are provided in three different levels of confidence. 
-These levels can be used in the authorization process by the relying party. 
-
-<a name="basic-binding"></a>
-### 3.1. Basic Binding (A)
-
-**URI:** `http://id.swedenconnect.se/id-binding/level/basic`
-
-**Description:** Basic level of confidence in binding as a result from an automated decision process when the eIDAS attributes from the foreign eID are matched to an individual's record in the Swedish population register.
-
-The following processes must have been applied:
-- `http://id.swedenconnect.se/id-binding/process/registered` ([4.1](#essential-matching-population-register))
-- `http://id.swedenconnect.se/id-binding/process/populationregister` ([4.2](#elevated-matching-population-register))
-
-<a name="enhanced-binding"></a>
-### 3.2. Enhanced Binding (B)
-
-**URI:** `http://id.swedenconnect.se/id-binding/level/enhanced`
-
-**Description:** In addition to meeting all the requirements for the basic level, 
-the binding can be endorsed with a higher confidence when the process 
-`http://id.swedenconnect.se/id-binding/process/nordicid` ([4.3](#nordic-id-in-population-register)) 
-can match attribute in the assertion from eIDAS to a registered Nordic identification number in the Swedish population register.
-
-In summary, following processes must have been applied:
-- `http://id.swedenconnect.se/id-binding/process/registered` ([4.1](#essential-matching-population-register))
-- `http://id.swedenconnect.se/id-binding/process/populationregister` ([4.2](#elevated-matching-population-register))
-- `http://id.swedenconnect.se/id-binding/process/nordicid` ([4.3](#nordic-id-in-population-register))
-    
-<a name="verified-binding"></a>
-### 3.3. Verified Binding (C)
-
-**URI:** `http://id.swedenconnect.se/id-binding/level/verified`
-
-**Description:** A mix of processes must be applied in order to achieve the highest level of 
-confidence in record matching. It requires the process `http://id.swedenconnect.se/id-binding/process/registered` ([4.1](#essential-matching-population-register)) combined with one of the following processes:
-
-- `http://id.swedenconnect.se/id-binding/process/swedish-eid` ([4.4](#use-of-swedish-eid))
-- `http://id.swedenconnect.se/id-binding/process/relative` ([4.5](#confirmed-by-relative))
-- `http://id.swedenconnect.se/id-binding/process/iddoc-scanning` ([4.6](#passport-or-id-card-scanning))
     
 <a name="identity-binding-processes"></a>
-## 4. Identity Binding Processes
+## 3. Identity Binding Processes
 
-This section contains a detailed description of the matching processes that
-are used by the Identity Binding Service. Each process is identified with an URI.
+This section contains a detailed description of the matching processes that are used by the Identity Binding Service. Each process is identified with an URI.
 
-> Note: The process URI:s are not part of a resulting SAML assertion. However, they will
-be stored in matching records and log entries.
+> Note: The process URI:s are not always included in the resulting SAML assertion. However, they will be stored in the log entries.
 
-<a name="essential-matching-population-register"></a>
-### 4.1. Essential Matching of Record in the Population Register
 
-**URI:** `http://id.swedenconnect.se/id-binding/process/registered`
+<a name="#identity-binding-user"></a>
+### 3.1. End-user Holds an Account in the Identity Binding Service
 
-**Description:** A binding process based on the fact that a Swedish identity number that has
-been provided by the end user is found in the Swedish population register. This record must
-belong to a living natural person, and its value for birth date must match the birth date 
-attribute from the eIDAS assertion. 
+**URI:** `http://id.swedenconnect.se/id-binding/process/registered-user`
 
-<a name="elevated-matching-population-register"></a>
-### 4.2. Elevated Matching of Record in the Population Register
+**Description:** The end-user has been authenticated using a foreign eID. Attributes provided via eIDAS, along with the end-user's statement of her/his Swedish identity number, meet the prerequisites for user registration. This verification includes confirming the record in the Swedish population register, ensuring it belongs to a living natural person, and validating that attribute values from eIDAS correspond to the date of birth and names registered in the record. Moreover, the end-user has accepted the terms of use and created a private storage in the Identity Binding Service.
+
+
+<a name="population-register"></a>
+### 3.2. End-user Holds a Copy of Record From the Swedish Population Register
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/populationregister`
 
-**Description:** Name attributes from an eIDAS assertion are matched against a record in
-the population register. A wide search in the population register shows that there are no
-other records found with the same birth date and name, thus, a decision for record matching
-can be made unambiguously.
+**Description:** The provided date of birth and names from eIDAS accurately correspond to the record in the population register. A detailed search in the population register confirms that there is a low risk of confusion, with no other records found that could potentially lead to ambiguity. The end-user holds a 
+machine-readable copy of the record retrieved from the Swedish population register. It's stored in the user's private storage and can be securely bound to end-user's eID in an unambiguous manner.
 
-<a name="nordic-id-in-population-register"></a>
-### 4.3. Nordic Identification Number Found in the Population Register
+
+<a name="nordic-id"></a>
+### 3.3. Nordic Identification Number Correspond to Record in the Swedish Population Register
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/nordicid`
 
-**Description:** A record in the population register contains an identity number from 
-an Nordic country and this number can be found in the eIDAS assertion.
+**Description:** The end-user holds a machine-readable copy of the record retrieved from the Swedish population register. This record includes an identification number from a Nordic country, which corresponds to the number found in the eIDAS assertion.
 
-<a name="use-of-swedish-eid"></a>
-### 4.4. Use of Swedish eID
+
+<a name="user-with-swedish-eid"></a>
+### 3.4. End-user Electronically Signed the Copy of Record by Using his/her Swedish eID
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/swedish-eid`
 
-**Description:** The end user, who has been authenticated with a foreign eID, can 
-prove a binding to the Swedish identity number by signing a confirmation with 
-his or her Swedish eID.
+**Description:** The end-user has electronically signed the record retrieved from the Swedish population register using a Swedish eID, which provides the end-user's Swedish identification number.
 
-**Additional requirements:** Assurance for the Swedish eID must be minimum at 
-level 3 in accordance of the 
+**Additional requirements:** Assurance level for the eID must be minimum at level 3 in accordance of the 
 [Swedish Trust Framework](https://www.digg.se/digitala-tjanster/e-legitimering/tillitsnivaer-for-e-legitimering/tillitsramverk-for-svensk-e-legitimation) 
-(a.k.a. [Tillitsramverk för 
-Svensk e-legitimation](https://www.digg.se/digitala-tjanster/e-legitimering/tillitsnivaer-for-e-legitimering/tillitsramverk-for-svensk-e-legitimation)). 
+(a.k.a. [Tillitsramverk för Svensk e-legitimation](https://www.digg.se/digitala-tjanster/e-legitimering/tillitsnivaer-for-e-legitimering/tillitsramverk-for-svensk-e-legitimation)). 
 Using the eID for this purpose must also be approved by the eID provider.
     
 <a name="confirmed-by-relative"></a>
-### 4.5. A Relative to End User has Confirmed the Binding
+### 5.5. A Relative to End-user Confirmed the Binding
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/relative`
 
-**Description:** A relative of the end user, logs in with his or her Swedish eID 
-and verifies the binding by signing a confirmation. The relationship must be official and 
-stored in the Swedish population register. Examples of valid relationships are spouses, parents 
-and children. 
+**Description:** A relative of the end-user signs in to the Identity Binding Service and vouches for the end-user to retrieve a machine-readable copy of the record from the Swedish population register. The relationship must be officially registered in the Swedish population register, and valid examples 
+of such relationships include spouses, parents, and children.
 
-**Additional requirements:** The relative must be at least 18 years old and use a 
-Swedish eID that meets the same requirements as in section [4.2](#use-of-swedish-eid) above.
+**Additional requirements:** The relative must be at least 18 years old and use an eID that meets the same requirements as in section [4.2](#user-with-swedish-eid) above.
 
-<a name="passport-or-id-card-scanning"></a>
-### 4.5. Passport or ID-card Scanning
-
-**URI:** `http://id.swedenconnect.se/id-binding/process/iddoc-scanning`
-
-**Description:** The end user, who has been authenticated with a foreign eID, can 
-prove binding to the Swedish identity number by reading a chip from a Swedish 
-identity document, such as passport or ID-card.
 
 <a name="versions"></a>
-## 5. Versions
+## 4. Versions
 
-- 2023-06-09: First version
-
+- 2023-06-09: First version.
+- 2024-05-08: Updated for release of the Identity Binding Service to the Sweden Connect QA environment.

--- a/Identity Binding.md
+++ b/Identity Binding.md
@@ -34,7 +34,7 @@ Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Go
 
     3.1. [End-user Holds an Account in the Identity Binding Service](#identity-binding-user)
 
-    3.2. [End-user Holds a Copy of Record From the Swedish Population Register](#population-register)
+    3.2. [End-user Holds a Copy of Record from the Swedish Population Register](#population-register)
     
     3.3. [Nordic Identification Number Correspond to Record in the Swedish Population Register](#nordic-id)
 
@@ -106,7 +106,7 @@ This section contains a detailed description of the matching processes that are 
 
 
 <a name="population-register"></a>
-### 3.2. End-user Holds a Copy of Record From the Swedish Population Register
+### 3.2. End-user Holds a Copy of Record from the Swedish Population Register
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/populationregister`
 

--- a/Identity Binding.md
+++ b/Identity Binding.md
@@ -146,5 +146,7 @@ The relationship must be officially registered in the Swedish population registe
 <a name="versions"></a>
 ## 4. Versions
 
+- 2024-05-08: Updated according to the latest legal agreements. The binding level is no longer used. Instead a set of identity binding process URL:s represent the binding.
+
 - 2023-06-09: First version.
-- 2024-05-08: Updated for release of the Identity Binding Service to the Sweden Connect QA environment.
+

--- a/Identity Binding.md
+++ b/Identity Binding.md
@@ -32,15 +32,13 @@ Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Go
     
 3. [**Identity Binding Processes**](#identity-binding-processes)
 
-    3.1. [End-user Holds an Account in the Identity Binding Service](#identity-binding-service-user)
-
-    3.2. [End-user Holds a Copy of Record from the Swedish Population Register](#population-register)
+    3.1. [Unique Record in the Population Register](#population-register)
     
-    3.3. [Nordic Identification Number Correspond to Record in the Swedish Population Register](#nordic-id)
+    3.2. [Nordic Identification Number Corresponding to Population Register Record](#nordic-id)
 
-    3.4. [End-user Electronically Signed the Copy of Record by Using his/her Swedish eID](#user-with-swedish-eid)
+    3.3. [Use of Swedish eID](#user-with-swedish-eid)
     
-    3.5. [A Relative to End-user Confirmed the Binding](#confirmed-by-relative)
+    3.4. [Relative Confirms Binding](#confirmed-by-relative)
  
 4. [**Versions**](#versions)
     
@@ -63,7 +61,7 @@ from the Identity Binding Service.
 The Identity Binding Service can be used by end-users, who are authenticated through eIDAS under specific conditions:
 
 - The end-user must have a registered record in terms of Swedish personal identity number (a.k.a. personnummer) or Swedish coordination number (a.k.a. samordningsnummer) in the Swedish population register.
-- The end-user must opt to associate this record to his or her eIDAS notified eID.
+- The end-user must opt to associate this record to his or hers eIDAS notified eID.
 
 Once an end-user's Swedish record is linked to hir or her foreing eID, the Swedish eIDAS node can include this information in the assertion provided to the relying party.
 
@@ -71,7 +69,7 @@ Once an end-user's Swedish record is linked to hir or her foreing eID, the Swedi
 <a name="making-a-binding"></a>
 ### 2.1. Making a Binding
 
-A user can make an identity binding through a various [Identity Binding Processes](#identity-binding-processes). These processes are run independently or in combination, aimed at achieving a clear and unambiguous identity binding.
+A user can make an identity binding through various [Identity Binding Processes](#identity-binding-processes). These processes are run independently or in combination, aimed at achieving a clear and unambiguous identity binding.
     
 <a name="eidas-node-queries"></a>
 ### 2.2. eIDAS-node Queries
@@ -94,40 +92,39 @@ See also sections 2.5, "eIDAS Natural Person Attribute Set", and 3.3.2, "The map
 
 This section contains a detailed description of the matching processes that are used by the Identity Binding Service. Each process is identified with an URI.
 
-> Note: The process URI:s are not always included in the resulting SAML assertion. However, they will be stored in the log entries.
+The prerequisites for all bindings described below are the following: The end-user has been authenticated using a foreign eID. Attributes provided via eIDAS, along with the end-user's statement of her/his Swedish identity number, meet the prerequisites for user registration. This verification includes:
 
+- confirming the record in the Swedish population register,
+- ensuring it belongs to a living natural person,
+- validating that attribute values from eIDAS assertion correspond to the date of birth and names registered in the record. 
 
-<a name="#identity-binding-service-user"></a>
-### 3.1. End-user Holds an Account in the Identity Binding Service
+Moreover, the end-user has accepted the terms of use and created a private storage in the Identity Binding Service.
 
-**URI:** `http://id.swedenconnect.se/id-binding/process/registered-user`
-
-**Description:** The end-user has been authenticated using a foreign eID. Attributes provided via eIDAS, along with the end-user's statement of her/his Swedish identity number, meet the prerequisites for user registration. This verification includes confirming the record in the Swedish population register, ensuring it belongs to a living natural person, and validating that attribute values from eIDAS correspond to the date of birth and names registered in the record. Moreover, the end-user has accepted the terms of use and created a private storage in the Identity Binding Service.
-
+**Note:** If the above steps uniquely corresponds to exactly one record in the Swedish population register, the binding `http://id.swedenconnect.se/id-binding/process/populationregister` ([3.1](#population-register)) will be created, but, if the birth date and name information from the eIDAS assertion matches more than one record from the population register, other processes (as described below) need to be applied for a binding to be completed.
 
 <a name="population-register"></a>
-### 3.2. End-user Holds a Copy of Record from the Swedish Population Register
+### 3.1. Unique Record in the Population Register
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/populationregister`
 
-**Description:** The provided date of birth and names from eIDAS accurately correspond to the record in the population register. A detailed search in the population register confirms that there is a low risk of confusion, with no other records found that could potentially lead to ambiguity. The end-user holds a 
-machine-readable copy of the record retrieved from the Swedish population register. It's stored in the user's private storage and can be securely bound to end-user's eID in an unambiguous manner.
+**Description:** The provided date of birth and name information from the eIDAS assertion uniquely matches only one record in the population register. 
 
+A detailed search in the population register confirms that there is a low risk of confusion, with no other records found that could potentially lead to ambiguity. The end-user holds a 
+machine-readable copy of the record retrieved from the Swedish population register. It is stored in the user's private storage and can be securely bound to end-user's eID in an unambiguous manner.
 
 <a name="nordic-id"></a>
-### 3.3. Nordic Identification Number Correspond to Record in the Swedish Population Register
+### 3.2. Nordic Identification Number Corresponding to Population Register Record
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/nordicid`
 
 **Description:** The end-user holds a machine-readable copy of the record retrieved from the Swedish population register. This record includes an identification number from a Nordic country, which corresponds to the number found in the eIDAS assertion.
 
-
 <a name="user-with-swedish-eid"></a>
-### 3.4. End-user Electronically Signed the Copy of Record by Using his/her Swedish eID
+### 3.3. Use of Swedish eID
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/swedish-eid`
 
-**Description:** The end-user has electronically signed the record retrieved from the Swedish population register using a Swedish eID, which provides the end-user's Swedish identification number.
+**Description:** The end-user has digitally signed an attestation connecting an eIDAS identity number to a record retrieved from the Swedish population register using a Swedish eID. Using this process the user proves the he or she holds both the eIDAS identity (received from the eIDAS authentication) and the Swedish identity number (received from the digital signature).
 
 **Additional requirements:** Assurance level for the eID must be minimum at level 3 in accordance of the 
 [Swedish Trust Framework](https://www.digg.se/digitala-tjanster/e-legitimering/tillitsnivaer-for-e-legitimering/tillitsramverk-for-svensk-e-legitimation) 
@@ -135,14 +132,15 @@ machine-readable copy of the record retrieved from the Swedish population regist
 Using the eID for this purpose must also be approved by the eID provider.
     
 <a name="confirmed-by-relative"></a>
-### 5.5. A Relative to End-user Confirmed the Binding
+### 3.4. Relative Confirms Binding
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/relative`
 
-**Description:** A relative of the end-user signs in to the Identity Binding Service and vouches for the end-user to retrieve a machine-readable copy of the record from the Swedish population register. The relationship must be officially registered in the Swedish population register, and valid examples 
-of such relationships include spouses, parents, and children.
+**Description:** A relative of the end-user logs in to the Identity Binding Service and vouches for the end-user to retrieve a machine-readable copy of the record from the Swedish population register. The relative digitally signs this attestation.
 
-**Additional requirements:** The relative must be at least 18 years old and use an eID that meets the same requirements as in section [4.2](#user-with-swedish-eid) above.
+The relationship must be officially registered in the Swedish population register, and valid examples of such relationships include spouses, parents, and children.
+
+**Additional requirements:** The relative must be at least 18 years old and use an eID that meets the same requirements as in section [3.3](#user-with-swedish-eid) above.
 
 
 <a name="versions"></a>

--- a/Identity Binding.md
+++ b/Identity Binding.md
@@ -32,7 +32,7 @@ Copyright &copy; <a href="https://www.digg.se">The Swedish Agency for Digital Go
     
 3. [**Identity Binding Processes**](#identity-binding-processes)
 
-    3.1. [End-user Holds an Account in the Identity Binding Service](#identity-binding-user)
+    3.1. [End-user Holds an Account in the Identity Binding Service](#identity-binding-service-user)
 
     3.2. [End-user Holds a Copy of Record from the Swedish Population Register](#population-register)
     
@@ -97,7 +97,7 @@ This section contains a detailed description of the matching processes that are 
 > Note: The process URI:s are not always included in the resulting SAML assertion. However, they will be stored in the log entries.
 
 
-<a name="#identity-binding-user"></a>
+<a name="#identity-binding-service-user"></a>
 ### 3.1. End-user Holds an Account in the Identity Binding Service
 
 **URI:** `http://id.swedenconnect.se/id-binding/process/registered-user`


### PR DESCRIPTION
Updated version according to the latest legal agreements. The binding level is no longer used. Instead a set of identity binding process URL:s represent the binding.

Closes #207 